### PR TITLE
Add check if http_x_forwarded_proto is https

### DIFF
--- a/shared/php-fpm/rootfs/etc/nginx/php-fpm-file.conf
+++ b/shared/php-fpm/rootfs/etc/nginx/php-fpm-file.conf
@@ -29,6 +29,12 @@ if ($http_x_use_https = on) {
     set $fastcgi_param_server_port      443;
 }
 
+if ($http_x_forwarded_proto = https) {
+    set $fastcgi_param_https            on;
+    set $fastcgi_param_http_scheme      https;
+    set $fastcgi_param_server_port      443;
+}
+
 if ($http_x_real_ip) {
     set $fastcgi_param_remote_addr      $http_x_real_ip;
 }


### PR DESCRIPTION
I added an additional check for the `http_x_forwarded_proto` header.

If the header value is `https` the server parameters `https`, `http_scheme` and `server_port` are set like the check for the `http_x_use_https` header.