### PR TITLE
feat: move nginx location config

### DIFF
--- a/images/nginx/rootfs/etc/nginx/location.d/20-default-route.location
+++ b/images/nginx/rootfs/etc/nginx/location.d/20-default-route.location
@@ -1,0 +1,3 @@
+location / {
+    root /var/www;
+}

--- a/images/nginx/rootfs/etc/nginx/nginx.conf
+++ b/images/nginx/rootfs/etc/nginx/nginx.conf
@@ -8,6 +8,8 @@ http {
         listen 80;
         root /var/www;
 
+        include location.d/*;
+
         include hidden-files.conf;
         include health.conf;
     }


### PR DESCRIPTION
This moves the location config inside the /etc/nginx/location.d/ folder. The default configuration uses the number 20.

Fixes #52