### PR TITLE
Build script update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ The following table show the directory layout of this repository:
 | `build_order`| File to defined the order used while building all images |
 | `build.sh`| build.sh is a script for building and/or pushing all or single image/s |
 
+## build.sh
+To function properly build.sh needs a few things from your machine. It uses the buildx feature of docker, therefore you need to install `docker`.
+Buildx uses a container on your machine to build the images. Please create said container using the following command from inside the project root: 
+```bash
+docker buildx create --name whatwedo-builder --config buildkit.toml --use
+```
+This will automatically load the configuration from the buildkit.toml in this project.
+For an example on how to configure buildkit take a look at this [GitHub Repo](https://github.com/docker/buildx/blob/master/docs/guides/custom-registry-config.md).
 
 ## Installed Software
 

--- a/build.sh
+++ b/build.sh
@@ -10,114 +10,131 @@ GIT_BRANCH=`git rev-parse --abbrev-ref HEAD | sed  's/\//-/g'`
 DATE=`date +%Y%m%d`
 export DOCKER_BUILDKIT=1
 
-# Build single image
-build_image() {
+
+
+
+config() {
     # Configuration
     IMAGE_NAME=$1
     IMAGE_DIR=$DIR/images/$IMAGE_NAME
     FULL_IMAGE_NAME=whatwedo/$IMAGE_NAME:$GIT_BRANCH
+}
 
-    # Build image
-    echo Building image $FULL_IMAGE_NAME
+check_image_dir_exists() {
+    if [ ! -d "$IMAGE_DIR" ]; then
+        tput setaf 1
+        echo "[ERROR] Image does not exist!"
+        tput sgr0
+        exit 1
+    fi
+}
+
+
+# The build_multiarch function will generate images for the needed architectures. It uses `docker buildx build` and will automatically PUSH THE IMAGE!
+build_multiarch() {
+    echo "[INFO] Selecting build-container"
+    docker buildx use whatwedo-builder
+
+    check_image_dir_exists
+
+    echo "[INFO] Building and pushing image: $FULL_IMAGE_NAME"
     rm -rf $IMAGE_DIR/shared
     cp -R $DIR/shared $IMAGE_DIR
-    docker build --platform linux/amd64 --no-cache --network host -t $FULL_IMAGE_NAME --build-arg VERSION=$GIT_BRANCH $IMAGE_DIR
+
+    # Build and push image
+    docker buildx build --no-cache \
+        -t $FULL_IMAGE_NAME \
+        --platform linux/amd64 \
+        --build-arg VERSION=$GIT_BRANCH \
+        --push \
+        $IMAGE_DIR
+}
+
+# To test the image it will use the normal way of building docker images via `docker build`
+test() {
+    echo "[INFO] Locally building and testing image: $FULL_IMAGE_NAME"
+
+    check_image_dir_exists
+
+    rm -rf $IMAGE_DIR/shared
+    cp -R $DIR/shared $IMAGE_DIR
+
+    # Build image
+    docker build --no-cache \
+        -t $FULL_IMAGE_NAME \
+        --build-arg VERSION=$GIT_BRANCH \
+        $IMAGE_DIR
 
     # Test image
-    echo Testing image $IMAGE_NAME
+    echo "[INFO] Testing image: $FULL_IMAGE_NAME"
     CID=`docker run -d --rm $FULL_IMAGE_NAME`
     docker exec $CID goss validate --retry-timeout 30s --sleep 1s
     docker kill $CID
 }
 
-# Push single image
-push_image() {
-    # Configuration
-    IMAGE_NAME=$1
-    FULL_IMAGE_NAME=whatwedo/$IMAGE_NAME:$GIT_BRANCH
-    FULL_IMAGE_NAME_DATE=$FULL_IMAGE_NAME-$DATE
-    FULL_IMAGE_NAME_MIRROR=registry.whatwedo.ch/whatwedo/docker-base-images/$IMAGE_NAME:$GIT_BRANCH
 
-    # Tag
-    docker tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_DATE
-    docker tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_MIRROR
-
-    # Push image
-    echo Pushing image $FULL_IMAGE_NAME
-    docker push $FULL_IMAGE_NAME
-    docker push $FULL_IMAGE_NAME_DATE
-    docker push $FULL_IMAGE_NAME_MIRROR
+test_all() {
+    echo "[INFO] Testing all images locally"
+    while read IMAGE_NAME; do
+        config $IMAGE_NAME
+        test
+    done < $BUILD_ORDER_FILE
 }
 
-# Push single image
-mirror_image() {
-    # Configuration
-    IMAGE_NAME=$1
-    FULL_IMAGE_NAME=whatwedo/$IMAGE_NAME:$GIT_BRANCH
-    FULL_IMAGE_NAME_MIRROR=registry.whatwedo.ch/whatwedo/docker-base-images/$IMAGE_NAME:$GIT_BRANCH
-
-    # Tag
-    docker tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_MIRROR
-
-    # Push image
-    echo Pushing image $FULL_IMAGE_NAME
-    docker push $FULL_IMAGE_NAME_MIRROR
-}
-
-# Building all images
 build_all() {
-    echo Building all images
+    echo "[INFO] Building and pushing all images"
     while read IMAGE_NAME; do
-        build_image $IMAGE_NAME
+        config $IMAGE_NAME
+        build_multiarch
     done < $BUILD_ORDER_FILE
 }
 
-# Pushing all images
-push_all() {
-    echo Pushing all images
-    while read IMAGE_NAME; do
-        push_image $IMAGE_NAME
-    done < $BUILD_ORDER_FILE
-}
 
-# Mirror all images
-mirror_all() {
-    echo Mirror all images
-    while read IMAGE_NAME; do
-        mirror_image $IMAGE_NAME
-    done < $BUILD_ORDER_FILE
-}
+
 
 # Display help
 help() {
     echo "
   build.sh is a script for building docker images in this repository.
 
+  In order to use the build command you will need to create a builder.
+  Check the README for more info on how to create and configure said builder!
+
   USAGE:
-  ./build.sh [image-name]                        - Build given image
-  ./build.sh [image-name] --push                 - Build and push given image
-  ./build.sh                                     - Build all images
-  ./build.sh --push                              - Build and push all images
-  ./build.sh --mirror                            - Mirror all images to registry.whatwedo.ch
+  ./build.sh test                                - Build and test all images locally
+  ./build.sh test [image-name]                   - Build and test the image locally
+  ./build.sh build                               - Build all images for multiple architectures and push them directly
+  ./build.sh build [image-name]                  - Build the image for multiple architectures and push it directly
   ./build.sh --help                              - Display this message
   "
 }
 
+
+
+
+# ./build.sh --help
 if [[ "$@" == "--help" ]]; then
     help
-elif [[ $# -eq 1 ]] && [[ "$1" != "--mirror" ]]; then
-    push_all
-    mirror_all
-elif [[ $# -eq 1 ]] && [[ "$1" != "--push" ]]; then
-    build_image $1
-elif [[ $# -eq 2 ]] && [[ "$2" == "--push" ]]; then
-    build_image $1
-    push_image $1
-elif [[ $# -eq 0 ]]; then
+
+# ./build.sh test [image-name]
+elif [[ $# -eq 2 ]] && [[ "$1" == "test" ]]; then
+    config $2
+    test
+
+# ./build.sh build [image-name]
+elif [[ $# -eq 2 ]] && [[ "$1" == "build" ]]; then
+    config $2
+    build_multiarch
+
+# ./build.sh test
+elif [[ $# -eq 1 ]] && [[ "$1" == "test" ]]; then
+    test_all
+
+# ./build.sh build
+elif [[ $# -eq 1 ]] && [[ "$1" == "build" ]]; then
     build_all
-elif [[ $# -eq 1 ]] && [[ "$1" == "--push" ]]; then
-    build_all
-    push_all
+
+# ./build.sh
 else
 	help
 fi

--- a/buildkit.toml
+++ b/buildkit.toml
@@ -1,0 +1,2 @@
+
+[registry."registry.whatwedo.ch"]

--- a/images/base/rootfs/sbin/upstart
+++ b/images/base/rootfs/sbin/upstart
@@ -11,7 +11,7 @@ _term() {
 trap _term SIGTERM
 
 # Run upstart files
-find /etc/upstart -mindepth 1 -maxdepth 1 -type f | sort -n | xargs -r -n 1 -- sh -c 'echo Running upstart file $0... && $0'
+find /etc/upstart -mindepth 1 -maxdepth 1 -type f | sort -n | xargs -r -n 1 -- time -f "%E" sh -c 'echo Running upstart file $0... && $0'
 
 # Run runit
 echo Running runit services...


### PR DESCRIPTION
Rebuild the build.sh script to summarize tasks and remove unused attributes.
It also enables multi-arch builds with docker. That means you can now create images for different CPU architectures on your own or on a remote machine.

This pull request also contains the feature of #44 