### PR TITLE
PHP: add env variables to profile.d

### DIFF
--- a/images/php/Dockerfile
+++ b/images/php/Dockerfile
@@ -9,4 +9,6 @@ RUN chmod 777 /tmp
 ENV PHP_VERSION=82
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN /tmp/install-php.sh && \
-    rm /tmp/install-php.sh
+    rm /tmp/install-php.sh && \
+    echo "COMPOSER_ALLOW_SUPERUSER=$COMPOSER_ALLOW_SUPERUSER" >> /etc/profile.d/php.sh && \
+    echo "PHP_VERSION=$PHP_VERSION" >> /etc/profile.d/php.sh


### PR DESCRIPTION
in some CI systems (f.ex. gitlab) the docker env variables are not available.